### PR TITLE
add STRING_ARRAY context and "string_array" filter

### DIFF
--- a/examples/arrays.js
+++ b/examples/arrays.js
@@ -1,0 +1,40 @@
+import { Schema, Fields, Field, STRING_ARRAY, Collision } from '../lib';
+
+// Create your data schema
+// This is a simple example with only one ARRAY field
+const profile = Schema({
+  machine: 'product',
+  // Outline allowed scopes
+  scope: ['r', 'w'],
+  // Outline allowed roles
+  roles: ['guest', 'user'],
+  // Outline schema blueprints
+  // In this case we are adding directly but best to create externally and import
+  blueprints: Fields([
+    Field({
+      machine: 'tags',
+      label: 'Tags',
+      context: STRING_ARRAY,
+    }),
+  ]),
+});
+// Create a collider to handle applying data to the schema
+const collider = Collision({
+  // Add the profile we are colliding with
+  model: profile,
+  // Add the scope for this collide
+  scope: ['r'],
+  // Add the roles for this collide
+  roles: ['guest'],
+});
+// Apply the data to the schema and dump the values
+collider
+  .with({
+    tags: ['GREEN', 'BLUE']
+  })
+  .collide()
+  .then(collider.dump)
+  .then((values) => {
+    // Returns ['GREEN', 'BLUE']
+    console.log(values);
+  });

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -11,6 +11,7 @@ module.exports = {
     examples: {
       default: 'npx nps examples.simple',
       simple: "npx babel-node ./examples/simple.js",
+      arrays: "npx babel-node ./examples/arrays.js",
       conditions: "npx babel-node ./examples/conditions.js",
       container: "npx babel-node ./examples/container.js",
       flatten: "npx babel-node ./examples/flatten.js",

--- a/src/Blueprint/Context/STRING_ARRAY.ts
+++ b/src/Blueprint/Context/STRING_ARRAY.ts
@@ -1,0 +1,12 @@
+import { SimpleSanitizer } from '../../Sanitize';
+import { Context } from './Types';
+
+export const STRING_ARRAY: Context = {
+  code: 'array',
+  children: false,
+  repeater: false,
+  sanitizers: [SimpleSanitizer({ filters: ['string_array'] })],
+  validators: [],
+};
+
+export default STRING_ARRAY;

--- a/src/Blueprint/Context/__tests__/STRING_ARRAY.test.ts
+++ b/src/Blueprint/Context/__tests__/STRING_ARRAY.test.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import { STRING_ARRAY } from '../';
+import { Field } from '../../';
+import { Hydrate } from '../../../Effect';
+import { Schema } from '../../../Model';
+import { Collision } from '../../../Interact';
+import { Fields } from '../../index';
+
+describe('Blueprint/Context/STRING_ARRAY', () => {
+  const fakeBlueprint = Field({
+    machine: 'example',
+    context: STRING_ARRAY,
+  });
+
+  const fakeModel = Schema({
+    machine: 'test',
+    roles: ['user', 'admin'],
+    scope: ['read', 'write'],
+    blueprints: Fields([Field({ machine: 'example', context: STRING_ARRAY })]),
+  });
+
+  const fakeEffect = (options: any = {}) =>
+    Hydrate({
+      collider: Collision({
+        model: fakeModel,
+        roles: ['user', 'admin'],
+        scope: ['read', 'write'],
+      }),
+      blueprint: fakeModel.blueprints.blueprints[0],
+      ...options,
+    });
+
+  it('can add validators to the parent blueprint', () => {
+    expect(fakeBlueprint.sanitizers.sanitizers).to.deep.equal(
+      STRING_ARRAY.sanitizers
+    );
+    expect(fakeBlueprint.validators.validators).to.deep.equal(
+      STRING_ARRAY.validators
+    );
+  });
+
+  it('can convert an array of numbers to an array of strings', () => {
+    const fakeField = fakeEffect({ value: [42] });
+    return fakeBlueprint
+      .sanitize({ value: fakeField.getValue(), effect: fakeField })
+      .then((sanitized) => {
+        expect(sanitized).to.deep.equal(['42']);
+      });
+  });
+});

--- a/src/Blueprint/Context/index.ts
+++ b/src/Blueprint/Context/index.ts
@@ -1,7 +1,8 @@
-export * from "./Types";
-export { default as BOOLEAN } from "./BOOLEAN";
-export { default as COLLECTION } from "./COLLECTION";
-export { default as CONTAINER } from "./CONTAINER";
-export { default as FLOAT } from "./FLOAT";
-export { default as INT } from "./INT";
-export { default as STRING } from "./STRING";
+export * from './Types';
+export { default as BOOLEAN } from './BOOLEAN';
+export { default as COLLECTION } from './COLLECTION';
+export { default as CONTAINER } from './CONTAINER';
+export { default as FLOAT } from './FLOAT';
+export { default as INT } from './INT';
+export { default as STRING } from './STRING';
+export { default as STRING_ARRAY } from './STRING_ARRAY';

--- a/src/Sanitize/Filter/index.ts
+++ b/src/Sanitize/Filter/index.ts
@@ -1,6 +1,7 @@
-export { default as floatFilter } from "./floatFilter";
-export { default as intFilter } from "./intFilter";
-export { default as lowerCaseFilter } from "./lowerCaseFilter";
-export { default as stringFilter } from "./stringFilter";
-export { default as trimFilter } from "./trimFilter";
-export { default as upperCaseFilter } from "./upperCaseFilter";
+export { default as floatFilter } from './floatFilter';
+export { default as intFilter } from './intFilter';
+export { default as lowerCaseFilter } from './lowerCaseFilter';
+export { default as stringFilter } from './stringFilter';
+export { default as trimFilter } from './trimFilter';
+export { default as upperCaseFilter } from './upperCaseFilter';
+export { default as stringArrayFilter } from './stringArrayFilter';

--- a/src/Sanitize/Filter/stringArrayFilter.ts
+++ b/src/Sanitize/Filter/stringArrayFilter.ts
@@ -1,0 +1,8 @@
+import stringFilter from './stringFilter';
+
+export const stringArrayFilter = (value: any) =>
+  Array.isArray(value)
+    ? value.map((valueItem) => stringFilter(valueItem))
+    : undefined;
+
+export default stringArrayFilter;

--- a/src/Sanitize/SimpleSanitizer.ts
+++ b/src/Sanitize/SimpleSanitizer.ts
@@ -1,19 +1,20 @@
-import _ from "lodash";
-import { getMixedResult } from "../Utils";
+import _ from 'lodash';
+import { getMixedResult } from '../Utils';
 import {
   floatFilter,
   intFilter,
   lowerCaseFilter,
   stringFilter,
+  stringArrayFilter,
   trimFilter,
-  upperCaseFilter
-} from "./Filter";
+  upperCaseFilter,
+} from './Filter';
 import {
   FiltersType,
   Sanitizer,
   SanitizerApplyArgs,
-  SanitizerArgs
-} from "./Types";
+  SanitizerArgs,
+} from './Types';
 
 /**
  * Provides a simple sanitizer with commonly used sanitizers
@@ -40,9 +41,10 @@ export class SimpleSanitizer implements Sanitizer {
    * @returns {Promise<string>}
    */
   public getFilters = async (options: any = {}): Promise<string> => {
-    return getMixedResult(this.filters, { ...this.options, ...options }).then(
-      built => built.join("|")
-    );
+    return getMixedResult(this.filters, {
+      ...this.options,
+      ...options,
+    }).then((built) => built.join('|'));
   };
 
   /**
@@ -55,28 +57,31 @@ export class SimpleSanitizer implements Sanitizer {
   public apply = async ({
     value,
     effect,
-    options
+    options,
   }: SanitizerApplyArgs): Promise<any> => {
     const filters: string = await this.getFilters(options);
     const unsanitized: any = _.isFunction(value) ? await value(options) : value;
-    return filters.split("|").reduce((filtered: any, filter: string) => {
+    return filters.split('|').reduce((filtered: any, filter: string) => {
       switch (filter.toLowerCase()) {
-        case "string": {
+        case 'string': {
           return stringFilter(filtered);
         }
-        case "float": {
+        case 'string_array': {
+          return stringArrayFilter(filtered);
+        }
+        case 'float': {
           return floatFilter(filtered);
         }
-        case "int": {
+        case 'int': {
           return intFilter(filtered);
         }
-        case "trim": {
+        case 'trim': {
           return trimFilter(filtered);
         }
-        case "upper_case": {
+        case 'upper_case': {
           return upperCaseFilter(filtered);
         }
-        case "lower_case": {
+        case 'lower_case': {
           return lowerCaseFilter(filtered);
         }
         default: {

--- a/src/Sanitize/__tests__/SimpleSanitizer.test.ts
+++ b/src/Sanitize/__tests__/SimpleSanitizer.test.ts
@@ -1,121 +1,171 @@
-import { expect } from "chai";
-import SimpleSanitizer from "../SimpleSanitizer";
-import { Hydrate, Effect } from "../../Effect";
-import { Schema } from "../../Model";
-import { Collision } from "../../Interact";
-import { Field, Fields, STRING } from "../../Blueprint";
+import { expect } from 'chai';
+import SimpleSanitizer from '../SimpleSanitizer';
+import { Hydrate, Effect } from '../../Effect';
+import { Schema } from '../../Model';
+import { Collision } from '../../Interact';
+import { Field, Fields, STRING } from '../../Blueprint';
 
-describe("Santize/SimpleSanitizer", () => {
+describe('Santize/SimpleSanitizer', () => {
   const simplePromiseRule = () =>
-    new Promise(resolve => {
-      setTimeout(resolve, 100, ["sanitize_string"]);
+    new Promise((resolve) => {
+      setTimeout(resolve, 100, ['sanitize_string']);
     });
 
   const mockPromiseValue = () =>
-    new Promise(resolve => {
-      setTimeout(resolve, 100, "  johnny ");
+    new Promise((resolve) => {
+      setTimeout(resolve, 100, '  johnny ');
     });
 
   const fakeModel = Schema({
-    machine: "test",
-    roles: ["user", "admin"],
-    scope: ["read", "write"],
-    blueprints: Fields([Field({ machine: "first_name", context: STRING })])
+    machine: 'test',
+    roles: ['user', 'admin'],
+    scope: ['read', 'write'],
+    blueprints: Fields([Field({ machine: 'first_name', context: STRING })]),
   });
 
   const fakeEffect = (options: any = {}) =>
     Hydrate({
       collider: Collision({
         model: fakeModel,
-        roles: ["user", "admin"],
-        scope: ["read", "write"]
+        roles: ['user', 'admin'],
+        scope: ['read', 'write'],
       }),
       blueprint: fakeModel.blueprints.blueprints[0],
-      value: "John",
-      ...options
+      value: 'John',
+      ...options,
     });
 
-  it("can create a simple filters santizer", () => {
-    const filters = ["trim|sanitize_string"];
+  it('can create a simple filters santizer', () => {
+    const filters = ['trim|sanitize_string'];
     const sanitizer = SimpleSanitizer({ filters, options: { test: true } });
     expect(sanitizer.filters).to.deep.equal(filters);
     expect(sanitizer.options.test).to.equal(true);
   });
 
-  it("can create a mixed rule santizer", () => {
-    const filters = ["trim", simplePromiseRule];
+  it('can create a mixed rule santizer', () => {
+    const filters = ['trim', simplePromiseRule];
     const sanitizer = SimpleSanitizer({ filters });
     expect(sanitizer.filters).to.deep.equal(filters);
   });
 
-  it("get filters produces a usable santizer string", () => {
-    const filters = ["trim", simplePromiseRule];
+  it('get filters produces a usable santizer string', () => {
+    const filters = ['trim', simplePromiseRule];
     const sanitizer = SimpleSanitizer({ filters });
-    return sanitizer.getFilters().then(built => {
-      expect(built).to.equal("trim|sanitize_string");
+    return sanitizer.getFilters().then((built) => {
+      expect(built).to.equal('trim|sanitize_string');
     });
   });
 
-  it("sanitize a string using a single trim and upper_case filters", () => {
-    const filters = ["trim|upper_case"];
+  it('sanitize a string using a single trim and upper_case filters', () => {
+    const filters = ['trim|upper_case'];
     const sanitizer = SimpleSanitizer({ filters });
     return sanitizer
       .apply({
-        value: " johnny ",
-        effect: fakeEffect()
+        value: ' johnny ',
+        effect: fakeEffect(),
       })
-      .then(sanitized => {
-        expect(sanitized).to.equal("JOHNNY");
+      .then((sanitized) => {
+        expect(sanitized).to.equal('JOHNNY');
       });
   });
 
-  it("sanitize a promise value using a single trim and upper_case filters", () => {
-    const filters = ["trim|upper_case"];
+  it('sanitize a promise value using a single trim and upper_case filters', () => {
+    const filters = ['trim|upper_case'];
     const sanitizer = SimpleSanitizer({ filters });
     return sanitizer
       .apply({ value: mockPromiseValue, effect: fakeEffect() })
-      .then(sanitized => {
-        expect(sanitized).to.equal("JOHNNY");
+      .then((sanitized) => {
+        expect(sanitized).to.equal('JOHNNY');
       });
   });
 
-  it("sanitize a string using the trim filter", () => {
-    const filters = ["trim"];
+  it('sanitize a string using the trim filter', () => {
+    const filters = ['trim'];
     const sanitizer = SimpleSanitizer({ filters });
     return sanitizer
-      .apply({ value: " johnny ", effect: fakeEffect() })
-      .then(sanitized => {
-        expect(sanitized).to.equal("johnny");
+      .apply({ value: ' johnny ', effect: fakeEffect() })
+      .then((sanitized) => {
+        expect(sanitized).to.equal('johnny');
       });
   });
 
-  it("sanitize a string using the upper_case filter", () => {
-    const filters = ["upper_case"];
+  it('sanitize a string using the upper_case filter', () => {
+    const filters = ['upper_case'];
     const sanitizer = SimpleSanitizer({ filters });
     return sanitizer
-      .apply({ value: "johnny", effect: fakeEffect() })
-      .then(sanitized => {
-        expect(sanitized).to.equal("JOHNNY");
+      .apply({ value: 'johnny', effect: fakeEffect() })
+      .then((sanitized) => {
+        expect(sanitized).to.equal('JOHNNY');
       });
   });
 
-  it("sanitize a string using the lower_case filter", () => {
-    const filters = ["lower_case"];
+  it('sanitize a string using the lower_case filter', () => {
+    const filters = ['lower_case'];
     const sanitizer = SimpleSanitizer({ filters });
     return sanitizer
-      .apply({ value: "JOHNNY", effect: fakeEffect() })
-      .then(sanitized => {
-        expect(sanitized).to.equal("johnny");
+      .apply({ value: 'JOHNNY', effect: fakeEffect() })
+      .then((sanitized) => {
+        expect(sanitized).to.equal('johnny');
       });
   });
 
-  it("sanitize a string using an invalid sanitizer filter", () => {
-    const filters = ["invalidSanitizer"];
+  it('sanitize a string using an invalid sanitizer filter', () => {
+    const filters = ['invalidSanitizer'];
     const sanitizer = SimpleSanitizer({ filters });
     return sanitizer
-      .apply({ value: "johnny", effect: fakeEffect() })
-      .then(sanitized => {
-        expect(sanitized).to.equal("johnny");
+      .apply({ value: 'johnny', effect: fakeEffect() })
+      .then((sanitized) => {
+        expect(sanitized).to.equal('johnny');
+      });
+  });
+
+  it('sanitize a string using stringArray filter', () => {
+    const filters = ['string_array'];
+    const sanitizer = SimpleSanitizer({ filters });
+    return sanitizer
+      .apply({ value: 'johnny', effect: fakeEffect() })
+      .then((sanitized) => {
+        expect(sanitized).to.equal(undefined);
+      });
+  });
+
+  it('sanitize an empty array using stringArray filter', () => {
+    const filters = ['string_array'];
+    const sanitizer = SimpleSanitizer({ filters });
+    return sanitizer
+      .apply({ value: [], effect: fakeEffect() })
+      .then((sanitized) => {
+        expect(sanitized).to.deep.equal([]);
+      });
+  });
+
+  it('sanitize a string array using stringArray filter', () => {
+    const filters = ['string_array'];
+    const sanitizer = SimpleSanitizer({ filters });
+    return sanitizer
+      .apply({ value: ['johnny'], effect: fakeEffect() })
+      .then((sanitized) => {
+        expect(sanitized).to.deep.equal(['johnny']);
+      });
+  });
+
+  it('sanitize a number array using stringArray filter', () => {
+    const filters = ['string_array'];
+    const sanitizer = SimpleSanitizer({ filters });
+    return sanitizer
+      .apply({ value: [42], effect: fakeEffect() })
+      .then((sanitized) => {
+        expect(sanitized).to.deep.equal(['42']);
+      });
+  });
+
+  it('sanitize a mixture of numbers and strings using stringArray filter', () => {
+    const filters = ['string_array'];
+    const sanitizer = SimpleSanitizer({ filters });
+    return sanitizer
+      .apply({ value: [42, '43'], effect: fakeEffect() })
+      .then((sanitized) => {
+        expect(sanitized).to.deep.equal(['42', '43']);
       });
   });
 });


### PR DESCRIPTION
The purpose of this PR is to add a new context “STRING_ARRAY” and new filter “string_array”. The STRING_ARRAY context will apply a default sanitizer filter of “string_array”. The “string_array” filter firstly filters out non-array objects, then it applies the existing “string” filter to all of the values in the array.